### PR TITLE
Add `add` and `mul` instructions

### DIFF
--- a/lean/common.lean
+++ b/lean/common.lean
@@ -300,8 +300,15 @@ def rbx := reg64 3
 
 def flagreg (i:fin 32) := lhs.reg $ reg.concrete_flagreg i
 
-def cf := flagreg  0
-def of := flagreg 11
+def cf  := flagreg  0
+def pf  := flagreg  2
+def af  := flagreg  4
+def zf  := flagreg  6
+def sf  := flagreg  7
+def tf  := flagreg  8
+def if' := flagreg  9
+def df  := flagreg 10
+def of  := flagreg 11
 
 def st0 : lhs x86_80 := lhs.streg 0
 
@@ -319,6 +326,8 @@ inductive prim : type → Type
 | slice (w:ℕ) (u:ℕ) (l:ℕ) : prim (bv w .→ bv (u+1-l))
 -- `(sext i o)` sign extends an `i`-bit number to a `o`-bit number.
 | sext  (i:ℕ) (o:ℕ) : prim (bv i .→ bv o)
+-- `(uext i o)` unsigned extension of an `i`-bit number to a `o`-bit number.
+| uext  (i:ℕ) (o:ℕ) : prim (bv i .→ bv o)
 -- `(trunc i o)` truncates an `i`-bit number to a `o`-bit number.
 | trunc (i:ℕ) (o:ℕ) : prim (bv i .→ bv o)
 -- `(eq tp)` returns `true` if two values are equal.
@@ -341,6 +350,7 @@ def pp : Π{tp:type}, prim tp → string
 | ._ (mul i) := "mul " ++ i.pp
 | ._ (slice w u l) := "slice " ++ w.pp ++ " " ++ u.pp ++ " " ++ l.pp
 | ._ (sext i o) := "sext " ++ i.pp ++ " " ++ o.pp
+| ._ (uext i o) := "uext " ++ i.pp ++ " " ++ o.pp
 | ._ (trunc i o) := "trunc " ++ i.pp ++ " " ++ o.pp
 | ._ (eq tp) := "eq " ++ tp.pp
 | ._ (neq tp) := "neq " ++ tp.pp
@@ -370,6 +380,10 @@ instance (a:type) (f:type) : has_coe_to_fun (value (type.fn a f)) :=
 { F := λ_, Π(y:value a), value f
 , coe := app
 }
+
+instance (w:ℕ) : has_zero (value (bv w)) := sorry
+instance (w:ℕ) : has_one  (value (bv w)) := sorry
+instance (w:ℕ) : has_add  (value (bv w)) := sorry
 
 protected
 def is_app : Π{tp:type}, value tp → bool
@@ -405,6 +419,8 @@ def slice {w:nat_expr} (x:value (bv w)) (u:nat_expr) (l:nat_expr)
 def trunc {w:nat_expr} (x: bv w) (o:nat_expr) : bv o := prim.trunc w o x
 
 def sext {w:nat_expr} (x: bv w) (o:nat_expr) : bv o := prim.sext w o x
+
+def uext {w:nat_expr} (x: bv w) (o:nat_expr) : bv o := prim.uext w o x
 
 def neq {tp:type} (x y : tp) : bit := prim.neq tp x y
 

--- a/lean/instructions.lean
+++ b/lean/instructions.lean
@@ -19,51 +19,126 @@ local infix ≠ := neq
 
 local notation `⇑`:max x:max := coe1 x
 
+local notation ℕ := nat_expr
+
 infix `.=`:20 := set
+
+------------------------------------------------------------------------
+-- utility functions
+
+def msb {w:ℕ} (v : bv w) : bit := sorry
+def is_zero {w:ℕ} (v : bv w) : bit := sorry
+def least_byte {w:ℕ} (v : bv w) : bv 8 := sorry
+def even_parity {w:ℕ} (v : bv w) : bit := sorry
+
+def set_undefined {tp:type} (v : lhs tp) : semantics unit := sorry
+
+def set_overflow (b:bit) : semantics unit := do
+  cf .= b,
+  of .= b,
+  set_undefined sf,
+  set_undefined zf,
+  set_undefined af,
+  set_undefined pf
+
+def set_result_flags {w:ℕ} (res : value (bv w)) : semantics unit := do
+  sf .= msb res,
+  zf .= is_zero res,
+  pf .= even_parity (least_byte res)
+
+def uadd_overflows  {w:ℕ} (dest : value (bv w)) (src : value (bv w)) : bit := sorry
+def uadd4_overflows {w:ℕ} (dest : value (bv w)) (src : value (bv w)) : bit := sorry
+def sadd_overflows  {w:ℕ} (dest : value (bv w)) (src : value (bv w)) : bit := sorry
 
 ------------------------------------------------------------------------
 -- imul definition
 
 def imul : instruction :=
  definst "imul" $ do
-   let setOverflow (b:bit) : semantics unit := do
-         cf .= b,
-         of .= b in do
    pattern λ(src : bv 8), do
      tmp ← eval $ sext (⇑al) 16 * sext src _,
      ax .= tmp,
-     setOverflow $ sext tmp[[7..0]] _ ≠ tmp
+     set_overflow $ sext tmp[[7..0]] _ ≠ tmp
    pat_end,
    pattern λ(src : bv 16), do
      tmp ← eval $ sext (⇑ax) 32 * sext src _,
      dx .= tmp[[31..16]],
      ax .= tmp[[15.. 0]],
-     setOverflow $ sext tmp[[15..0]] _ ≠ tmp
+     set_overflow $ sext tmp[[15..0]] _ ≠ tmp
    pat_end,
    pattern λ(src : bv 32), do
      tmp ← eval $ sext ⇑eax 64 * sext src _,
      edx .= tmp[[63..32]],
      eax .= tmp[[31.. 0]],
-     setOverflow $ sext tmp[[31..0]] _ ≠ tmp
+     set_overflow $ sext tmp[[31..0]] _ ≠ tmp
    pat_end,
    pattern λ(w : one_of [8,16,32,64]) (dest : lhs (bv w)) (src : bv w), do
      tmp     ← eval $ sext ⇑dest (2*w) * sext src (2*w),
      tmp_low ← eval $ trunc tmp w,
      dest .= tmp_low,
-     setOverflow $ sext tmp_low (2*w) ≠ tmp
+     set_overflow $ sext tmp_low (2*w) ≠ tmp
    pat_end,
    pattern λ(w : one_of [16,32,64]) (dest : lhs (bv w)) (src1 src2 : bv w), do
      tmp     ← eval $ sext ⇑src1 (2*w) * sext src2 (2*w),
      tmp_low ← eval $ trunc tmp w,
      dest .= tmp_low,
-     setOverflow $ sext tmp_low (2*w) ≠ tmp
+     set_overflow $ sext tmp_low (2*w) ≠ tmp
    pat_end
+
+------------------------------------------------------------------------
+-- mul definition
+
+def mul : instruction := do
+ definst "mul" $ do
+   pattern λ(src : bv 8), do
+     tmp ← eval $ uext ⇑al 16 * uext src 16,
+     ax .= tmp,
+     set_overflow $ tmp[[16..8]] ≠ 0
+   pat_end,
+   pattern λ(src : bv 16), do
+     tmp ← eval $ uext (⇑ax) 32 * uext src _,
+     dx .= tmp[[31..16]],
+     ax .= tmp[[15.. 0]],
+     set_overflow $ tmp[[31..16]] ≠ 0
+   pat_end,
+   pattern λ(src : bv 32), do
+     tmp ← eval $ uext ⇑eax 64 * uext src _,
+     edx .= tmp[[63..32]],
+     eax .= tmp[[31.. 0]],
+     set_overflow $ tmp[[63..32]] ≠ 0
+   pat_end,
+   pattern λ(src : bv 64), do
+     tmp ← eval $ uext ⇑rax 128 * uext src _,
+     rdx .= tmp[[127..64]],
+     rax .= tmp[[63 .. 0]],
+     set_overflow $ tmp[[127..64]] ≠ 0
+   pat_end
+
+------------------------------------------------------------------------
+-- mov definition
 
 def mov : instruction := do
  definst "mov" $ do
    pattern λ(w : one_of [8,16,32,64]) (dest : lhs (bv w)) (src : bv w), do
      dest .= src
    pat_end
+
+------------------------------------------------------------------------
+-- add definition
+
+def add : instruction := do
+ definst "add" $ do
+   pattern λ(w : one_of [8, 16, 32, 64]) (dest : lhs (bv w)) (src : bv w), do
+     tmp ← eval $ ⇑dest + src,
+     set_result_flags tmp,
+     cf .= uadd_overflows tmp src,
+     of .= sadd_overflows tmp src,
+     af .= uadd4_overflows tmp src,
+     dest .= tmp
+   pat_end
+
+------------------------------------------------------------------------
+-- fadd definition
 
 def fadd : instruction := do
  definst "fadd" $ do
@@ -77,6 +152,9 @@ def fadd : instruction := do
      st0  .= x87_fadd st0 ↑src
    pat_end
 
+------------------------------------------------------------------------
+-- faddp definition
+
 def faddp : instruction := do
  definst "faddp" $ do
    pattern λ(dest : lhs x86_80) (src : lhs x86_80), do
@@ -84,11 +162,17 @@ def faddp : instruction := do
      record_event event.pop_x87_register_stack
    pat_end
 
+------------------------------------------------------------------------
+-- fiadd definition
+
 def fiadd : instruction := do
  definst "fiadd" $ do
    pattern λ(w : one_of [16,32]) (src : lhs (bv w)), do
      st0 .= x87_fadd st0 ↑src
    pat_end
+
+------------------------------------------------------------------------
+-- syscall definition
 
 def syscall : instruction :=
   definst "syscall" $ mk_pattern (record_event event.syscall)


### PR DESCRIPTION
There are a few other things mixed in here that were either necessary or good clean up:

  * `uext`
  * x86 flags
  * instances for `bv` so that we can construct literal bitvectors
  * misc utility functions for specifying function semantics
  * Unfortunately, also many `sorry`s