### PR TITLE
Bitvector clean and add new functions

### DIFF
--- a/lean/bitvec.lean
+++ b/lean/bitvec.lean
@@ -9,6 +9,7 @@ This is a work-in-progress, and contains additions to other theories.
 -/
 import data.vector
 import .nat.lemmas
+import .list.lemmas
 
 import tactic.find
 
@@ -63,6 +64,20 @@ end one
 protected def cong {a b : ℕ} (h : a = b) : bitvec a → bitvec b
 | ⟨x, p⟩ := ⟨x, h ▸ p⟩
 
+protected
+lemma intro {n : ℕ} (x y : bitvec n) : x.val = y.val → x = y :=
+begin
+  intro H,
+  cases x, cases y, congr,
+  simp at H, assumption
+end
+
+lemma cong_val {n m : ℕ} {H : n = m} (x : bitvec n)
+: (bitvec.cong H x).val = x.val :=
+begin
+  cases x, simp [bitvec.cong]
+end
+
 -- Most significant bit
 def msb {n:ℕ} (x: bitvec n) : bool := (nat.shiftl x (n-1)) = 1
 
@@ -85,6 +100,12 @@ section conversion
   variable {α : Type}
 
   protected def to_nat {n : nat} (v : bitvec n) : nat := v.val
+
+  lemma bitvec.eq {n:ℕ} (x y : bitvec n) (p : x.to_nat = y.to_nat) : x = y :=
+  begin
+    apply subtype.eq,
+    exact p,
+  end
 
   protected def to_int {n:ℕ} (x: bitvec n) : int :=
     match msb x with
@@ -144,6 +165,8 @@ section arith
 
   protected def add (x y : bitvec n) : bitvec n := bitvec.of_nat n (x.to_nat + y.to_nat)
 
+  def adc (x y : bitvec n) : bitvec n × bool := ⟨ bitvec.add x y , x.to_nat + y.to_nat > 2^n ⟩
+
   -- Usual arithmetic subtraction
   protected def sub (x y : bitvec n) : bitvec n := bitvec.of_int n (x.to_int - y.to_int)
 
@@ -194,61 +217,323 @@ section listlike
   def append {m n} (x: bitvec m) (y: bitvec n) : bitvec (m + n)
     := ⟨ x.val * 2^n + y.val, mul_pow_add_lt_pow x.property y.property ⟩
 
-  def trunc {n : ℕ} (x : bitvec n) (m : ℕ) : bitvec (min n m) := bitvec.of_nat (min n m) x.val
+  def trunc {n : ℕ} (m : ℕ) (x : bitvec (n+m)) : bitvec m := bitvec.of_nat m x.val
+
+  protected
+  def bsf' : Π{n:ℕ}, ℕ → bitvec n → option ℕ
+    | 0        idx _ := none
+    | (succ m) idx x :=
+      have H: succ m = 1 + m,
+      { simp, },
+      if idx > m
+        then none
+        else if nth x 0
+               then some idx
+               -- We actually don't need to trunc here, but by reducing the
+               -- the length of the bitvector on each recursive call
+               -- lean can easily prove that this function terminates.
+             else @bsf' m (idx+1) (trunc m (bitvec.cong H (x.ushr 1)))
+
+  -- index of least-significant bit that is 1.
+  def bsf : Π{n:ℕ}, bitvec n → option ℕ
+    | n x := bitvec.bsf' 0 x
+
+  protected
+  def bsr' : Π{n:ℕ}, ℕ → bitvec n → option ℕ
+    | 0        _   _ := none
+    | (succ m) idx x :=
+      have H: succ m = 1 + m,
+      { simp, },
+      if nth x idx
+        then some idx
+        else @bsr' m (idx-1) (trunc m (bitvec.cong H (x.ushr 1)))
+
+  -- index of the most-significant bit that is 1.
+  def bsr : Π{n:ℕ}, bitvec n → option ℕ
+    | n x := bitvec.bsr' (n-1) x
 
   -- splits a bitvector into {n .. m} {m - 1 .. 0} sub bitvectors
-  def split_at {n : ℕ} (m : ℕ) (x : bitvec n) : bitvec (n - m) × bitvec (min n m) := -- upper × lower
-    ⟨ bitvec.cong min_sub_self_right (trunc (ushr x m) (n - m)), trunc x m ⟩
+  def split_at {n : ℕ} (m : ℕ) (x : bitvec (n + m)) : bitvec n × bitvec m := -- upper × lower
+      ⟨ trunc n (bitvec.cong (nat.add_comm _ _) (ushr x m)), trunc m x ⟩
 
-  def split_at' {n m : ℕ} (H : m ≤ n) (x : bitvec n) : bitvec (n - m) × bitvec m := -- upper × lower
-      ⟨ (split_at m x).fst, bitvec.cong (min_eq_right H) ((split_at m x).snd) ⟩
-
-  lemma split_at_snd {n : ℕ} (m : ℕ) (x : bitvec n): (split_at m x).snd.val < 2 ^ m :=
+  lemma split_at_snd {n : ℕ} (m : ℕ) (x : bitvec (n+m)): (split_at m x).snd.val < 2 ^ m :=
     begin
       simp [split_at, trunc],
       apply nat.lt_of_lt_of_le,
       { apply mod_lt, apply nat.pos_pow_of_pos, dec_trivial_tac },
       { apply pow_le_pow_of_le_right,
         { dec_trivial_tac },
-        { apply min_le_right }
+        { refl }
       }
     end
 
-  lemma bitvec_intro {n : ℕ} (x y : bitvec n) : x.val = y.val → x = y :=
+  lemma trunc_add_ushr {n m : ℕ} (x : bitvec (n + m))
+  : (trunc m x).val + (trunc n (bitvec.cong (nat.add_comm _ _) (ushr x m))).val * 2 ^ m = x.val :=
   begin
-    intro H,
-    cases x, cases y, congr,
-    simp at H, assumption
-  end
-
-  lemma cong_val {n m : ℕ} {H : n = m} (x : bitvec n)
-  : (bitvec.cong H x).val = x.val :=
-  begin
-    cases x, simp [bitvec.cong]
-  end
-
-  lemma trunc_add_ushr {n m : ℕ} (H : m ≤ n) (x : bitvec n)
-  : (trunc x m).val + (trunc (ushr x m) (n - m)).val * 2 ^ m = x.val :=
-  begin
-    simp [ trunc, min_eq_right H, min_eq_right (sub_le n m), ushr, bitvec.of_nat, shiftr_eq_div_pow],
-    have : 2^(n - m) ≤ 2^n,
-    { apply pow_le_pow_of_le_right,
-      { dec_trivial_tac },
-      { apply nat.sub_le, },
-    },
-    have : x.val / 2 ^ m < 2 ^ n, { apply div_pow_mono x.property },
+    simp [ trunc, ushr, bitvec.of_nat, shiftr_eq_div_pow, cong_val],
+    have : x.val / 2 ^ m < 2 ^ (n + m),
+    { apply div_pow_mono x.property, },
     rw mod_eq_of_lt this,
-    rw (pow_mod_superfluous x.property H),
+    rw (pow_mod_superfluous' x.property),
     { rw mul_comm, apply mod_add_div }
   end
 
-  lemma split_at'_append_ident {n : ℕ} (m : ℕ) (H : m ≤ n) (x : bitvec n)
-  : append (split_at' H x).fst (split_at'  H x).snd = bitvec.cong (eq.symm (nat.sub_add_cancel H)) x :=
+  lemma split_at_append_ident {n : ℕ} (m : ℕ) (x : bitvec (n + m))
+  : append (split_at m x).fst (split_at m x).snd = x :=
   begin
-    apply bitvec_intro,
-    simp [append, split_at', cong_val, split_at],
-    apply (trunc_add_ushr H)
+    apply bitvec.intro,
+    simp [append, split_at],
+    apply trunc_add_ushr
   end
+
+  def chunks : Π(n :ℕ) (m : ℕ), bitvec (m * n) → list (bitvec m)
+    | 0             _ _  := []
+    | (nat.succ n)  m bv :=
+      let v := bitvec.split_at m bv
+      in  v.snd :: chunks n m v.fst
+
+  @[simp]
+  lemma chunks_nil {m:ℕ} {x: bitvec (m * 0) }: chunks _ m x = [] :=
+    by unfold chunks
+
+  @[simp]
+  lemma chunks_length {n m : ℕ} {x: bitvec (m * n)} : list.length (chunks n m x) = n :=
+  begin
+    induction n with n p,
+    case nat.zero
+    { unfold chunks, simp },
+    case nat.succ
+    { simp [chunks, p],
+    },
+  end
+
+  @[simp]
+  lemma chunks_length_mul {n m : ℕ} {x: bitvec (m * n)}
+  : m * list.length (chunks n m x) = m * n
+  := by simp
+
+  def concat : Π{n : ℕ}(input: list (bitvec n)), bitvec (n * input.length)
+    | _ []      := 0
+    | n (x::xs) := append (concat xs) x
+
+  @[simp]
+  lemma concat_nil_zero {n:ℕ} : concat ([]: list (bitvec n)) = (0 : bitvec 0) :=
+  begin
+    simp [concat], refl,
+  end
+
+  @[simp]
+  lemma concat_step {n:ℕ} (x: bitvec n) (xs: list (bitvec n))
+  : concat (x::xs) = append (concat xs) x :=
+  begin
+    simp [concat],
+  end
+
+  @[simp]
+  lemma chunks_concat_zero {n:ℕ} (x: bitvec (0 * n))
+  : concat (chunks n 0 x) = 0 :=
+  begin
+    induction n with n ih,
+    case nat.zero
+    { rw [chunks, concat] },
+    case nat.succ
+    { rw [chunks, concat],
+      apply bitvec.intro,
+      rw ih,
+      simp [cong_val, append, split_at, trunc, bitvec.of_nat],
+      refl
+    },
+  end
+
+  lemma chunks_concat_eq {n m:ℕ} (x: bitvec (m * n))
+  : concat (chunks n m x) = bitvec.cong (eq.symm chunks_length_mul) x :=
+  begin
+    apply bitvec.intro,
+    simp [cong_val],
+    induction n with n p,
+    case nat.zero
+    { simp [cong_val], },
+    case nat.succ
+    { rw [chunks, concat, split_at, append],
+      simp [p, cong_val],
+      apply trunc_add_ushr,
+    },
+  end
+
+  def chunks_nat : Π(n :ℕ) (m : ℕ), ℕ → list (bitvec m)
+  | 0            _ _ := []
+  | (nat.succ n) m v := (bitvec.of_nat m (nat.shiftr v (n*m)) :: chunks_nat n m v)
+
+  @[simp]
+  lemma chunks_nat_base {m:ℕ} (v:ℕ)
+    : chunks_nat 0 m v = [] :=
+    by simp [chunks_nat]
+
+  @[simp]
+  lemma chunks_nat_step {n m :ℕ} (v : ℕ)
+    : chunks_nat (succ n) m v =
+        (bitvec.of_nat m (nat.shiftr v (n*m)) :: chunks_nat n m v) :=
+    by simp [chunks_nat]
+
+  @[simp]
+  lemma chunks_nat_length {n m : ℕ} (v : ℕ)
+    : list.length (chunks_nat n m v) = n :=
+    begin
+      induction n with n ih,
+      case nat.zero
+      { simp, },
+      case nat.succ
+      { simp [chunks_nat_step], rw [ih, ←add_one, add_comm], },
+    end
+
+  @[simp]
+  lemma chunks_nat_zero {n m:ℕ}
+    : chunks_nat n m 0 = list.repeat 0 n :=
+    begin
+      induction n with n ih,
+      case nat.zero
+      { simp, },
+      case nat.succ
+      { simp [chunks_nat_step],
+        apply and.intro,
+        { simp [bitvec.of_nat],
+          refl,
+        },
+        { exact ih },
+      },
+    end
+
+  def chunks' (n m :ℕ) (v:bitvec (m * n)) : list (bitvec m) := chunks_nat n m v.to_nat
+
+  @[simp]
+  lemma chunks'_nil {m:ℕ} {x: bitvec (m * 0) }: chunks' _ m x = [] :=
+    begin
+      unfold chunks',
+      unfold chunks_nat,
+    end
+
+  @[simp]
+  lemma chunks'_length {n m : ℕ} {x: bitvec (m * n)} : list.length (chunks' n m x) = n :=
+  begin
+    induction n with n p,
+    case nat.zero
+    { unfold chunks', simp },
+    case nat.succ
+    { simp [chunks', p],
+    },
+  end
+
+  @[simp]
+  lemma chunks'_length_mul {n m : ℕ} {x: bitvec (m * n)}
+  : m * list.length (chunks' n m x) = m * n
+  := by simp
+
+  lemma chunks'_step {n m : ℕ} (v : bitvec (m * succ n))
+  : chunks' (succ n) m v = (bitvec.of_nat m (nat.shiftr v (n*m)) :: chunks_nat n m v) :=
+  begin
+    simp [chunks', chunks_nat],
+    apply and.intro; refl
+  end
+
+  def concat_nat {n : ℕ} : ℕ → list (bitvec n) → ℕ
+  | acc []      := acc
+  | acc (x::xs) := concat_nat (nat.shiftl acc n + x.to_nat) xs
+
+  @[simp]
+  lemma concat_nat_nil : ∀(n acc : ℕ), @concat_nat n acc list.nil = acc :=
+    begin
+      intros,
+      simp [concat_nat]
+    end
+
+  @[simp]
+  lemma concat_nat_step {n acc : ℕ} (x: bitvec n) (xs: list (bitvec n))
+    : concat_nat acc (x::xs) = concat_nat (nat.shiftl acc n + x.to_nat) xs :=
+    by simp [concat_nat]
+
+  lemma concat_nat_step_acc {n r : ℕ} (ls : list (bitvec n))
+  : concat_nat r ls = r * 2^(ls.length * n) + concat_nat 0 ls :=
+  begin
+    induction ls with l' ls' ih generalizing r,
+    case list.nil
+    { simp [concat_nat, mul_comm],
+    },
+    case list.cons
+    { simp [concat_nat, bitvec.to_nat, shiftl_eq_mul_pow],
+      rw [ih],
+      rw [@ih l'.val],
+      simp,
+      congr,
+      simp [right_distrib, pow_distrib, mul_assoc],
+    },
+  end
+
+  @[simp]
+  lemma concat_nat_zeros {n m:ℕ}
+  : @concat_nat n 0 (list.repeat 0 m) = 0 :=
+  begin
+    induction m with m ih,
+    case nat.zero
+    { simp, },
+    case nat.succ
+    { simp [bitvec.to_nat],
+      exact ih,
+    },
+  end
+
+  theorem concat_nat_zero_bound {n : ℕ} : ∀(l : list (bitvec n)),
+    concat_nat 0 l < 2^(n*l.length) :=
+  begin
+    intros,
+    induction l with l ls ih,
+    case list.nil
+    { simp, dec_trivial_tac },
+    case list.cons
+    { simp,
+      rw [concat_nat_step_acc, mul_comm n],
+      rw [mul_comm n ls.length] at ih,
+      simp,
+      rw [add_comm 1 ls.length],
+      apply (@add_pow_bound (concat_nat 0 ls) (bitvec.to_nat l) (ls.length) n ih l.property),
+    },
+  end
+
+  theorem concat_nat_bound {w:ℕ} {n:ℕ} : ∀(r:ℕ) (h:r < 2^w) (l:list (bitvec n)),
+    concat_nat r l < (r + 1)*2^(l.length * n) :=
+  begin
+    intros,
+    rw [concat_nat_step_acc],
+    calc
+      r * 2^(l.length * n) + concat_nat 0 l < r * 2^(l.length * n) + 2^(n * l.length)   : by apply nat.add_lt_add_left (concat_nat_zero_bound l)
+                                        ... = r * 2^(l.length * n) + 2^(l.length * n)   : by rw (mul_comm n)
+                                        ... = r * 2^(l.length * n) + 1*2^(l.length * n) : by simp
+                                        ... = (r+1)*2^(l.length * n)                    : by rw [←right_distrib]
+  end
+
+  def concat' {n : ℕ} (input: list (bitvec n)) : bitvec (n * input.length) :=
+   ⟨concat_nat 0 input, concat_nat_zero_bound input⟩
+
+  lemma chunks_nat_concat_nat_eq {n m:ℕ} (x: ℕ)
+  : concat_nat 0 (chunks_nat n m x) = x % 2^n :=
+  begin
+    induction n with n ih,
+    case nat.zero
+    { simp, },
+    case nat.succ
+    { have: 2 > 0, dec_trivial_tac,
+      rw [mod_pow_succ this],
+      rw [concat_nat_step_acc],
+      -- These simps cannot be combined, because it causes an error in the expander.
+      simp [bitvec.to_nat, shiftr_eq_div_pow, bitvec.of_nat],
+      simp [concat_nat_step_acc, ih],
+      -- NOTE: not sure how to finish this, but the goal holds for the
+      -- random inputs I tested it on.
+      admit
+    },
+  end
+
+  def slice {w: ℕ} (u l k:ℕ) (H: w = k + (u + 1 - l)) (x: bitvec w) : bitvec (u + 1 - l) :=
+    trunc (u + 1 - l) (bitvec.cong H (x.ushr l))
 
 end listlike
 

--- a/lean/list/lemmas.lean
+++ b/lean/list/lemmas.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2018 Galois. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Additional lemmas for natural numbers.
+
+This is a work-in-progress, and contains additions to other theories.
+-/
+
+import tactic.find
+import ..tactic
+
+open nat
+
+section reverse
+  universes u
+
+  lemma reverse_core_step {α : Type u} (x : α) (xs : list α) (ys : list α)
+  : list.reverse_core (x::ys) xs = list.reverse_core ys [] ++ x::xs :=
+  begin
+    induction ys with y ys ih generalizing x xs,
+    case list.nil
+    { simp [list.reverse_core], },
+    case list.cons
+    { rw [ih],
+      simp [list.reverse_core],
+      rw [←ih],
+      simp [list.reverse_core],
+    },
+  end
+
+  lemma reverse_length_nil {α : Type u} (xs : list α)
+  : list.length (list.reverse_core xs list.nil) = list.length xs :=
+  begin
+    induction xs with x xs ih,
+    case list.nil
+    { simp [list.reverse_core], },
+    case list.cons
+    { simp [reverse_core_step],
+      rw ih,
+    },
+  end
+
+  @[simp]
+  lemma length_reverse {α : Type u} {x : list α} : list.length (list.reverse x) = list.length x :=
+    begin
+      simp [list.reverse],
+      apply reverse_length_nil,
+    end
+
+  lemma reverse_step (α : Type u) (x : α) (ys : list α)
+  : list.reverse (x :: ys) = list.reverse ys ++ [x] :=
+  begin
+    induction ys with y ys ih,
+    case list.nil
+    { simp [list.reverse, list.reverse_core] },
+    case list.cons
+    { simp [list.reverse],
+      rw reverse_core_step,
+    },
+  end
+
+end reverse

--- a/lean/list/lemmas.lean
+++ b/lean/list/lemmas.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2018 Galois. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 
-Additional lemmas for natural numbers.
+Additional lemmas for lists.
 
 This is a work-in-progress, and contains additions to other theories.
 -/

--- a/lean/nat/lemmas.lean
+++ b/lean/nat/lemmas.lean
@@ -110,3 +110,214 @@ lemma pow_mod_superfluous {x n m : ℕ} (H : x < 2 ^ n) (Hm: m ≤ n): (x / 2 ^ 
 begin
   apply mod_eq_of_lt, apply (div_pow_mono' H Hm)
 end
+
+lemma le_mul_succ {n m : ℕ} : m ≤ m * (succ n) :=
+  begin
+    calc   m ≤ m * 1 : by simp
+         ... ≤ m * (nat.succ n) : begin
+                                    apply nat.mul_le_mul_left,
+                                    apply nat.succ_le_succ,
+                                    apply nat.zero_le
+                                  end
+  end
+
+lemma mul_right {m n k: ℕ} : m = n → k * m = k * n :=
+  begin
+    induction k with k ih,
+    case nat.zero
+    { simp, },
+    case nat.succ
+    { intros,
+      simp [right_distrib, ih a, a],
+    }
+  end
+
+lemma add_right {m n k: ℕ} : m = n → k + m = k + n :=
+  begin
+    induction k with k ih,
+    case nat.zero
+    { intros, simp, assumption },
+    case nat.succ
+    { intros, simp [ih, a] }
+  end
+
+lemma pow_intro {b i j :ℕ}
+  : i = j → b^i = b^j :=
+  begin
+    intros,
+    rw a,
+  end
+
+lemma pow_distrib {b i j :ℕ}
+  : b^(i+j) = b^i*b^j :=
+  begin
+    induction i with i ih,
+    case nat.zero
+    { simp, },
+    case nat.succ
+    { rw [pow_succ, nat.mul_assoc (b^i), nat.mul_comm b,
+          ←nat.mul_assoc (b^i), ←ih, ←pow_succ],
+      simp,
+    },
+  end
+
+lemma two_pow_div_eq {x m n : ℕ}
+  : 2^(m * succ n)/2^m = 2^(m*n) :=
+  begin
+    have two_pos: 0 < 2, dec_trivial_tac,
+    have: 2^(m * succ n) ≥ 2^m,
+    { apply pow_le_pow_of_le_right two_pos,
+      apply le_mul_succ,
+    },
+    have pow_two_pos: 2^m > 0,
+    { apply (pos_pow_of_pos _ two_pos),
+    },
+    have two_pow_mn_big: 1 ≤ 2^(m*n),
+    { apply nat.succ_le_of_lt,
+      apply (pos_pow_of_pos _ two_pos),
+    },
+    have two_pow_distrib: 2^(m*succ n) = 2^(m*n + m),
+    { apply pow_intro,
+      rw [←add_one, left_distrib],
+      simp,
+    },
+    calc
+    2^(m * succ n)/2^m = (2^(m*succ n) - 2^m)/2^m + 1   : by apply div_eq_sub_div (pos_pow_of_pos m two_pos) this
+                   ... = (2^(m*n + m) - 2^m)/2^m + 1    : by rw two_pow_distrib
+                   ... = (2^(m*n)*2^m - 2^m)/2^m + 1    : by rw pow_distrib
+                   ... = (2^m*2^(m*n) - 2^m)/2^m + 1    : by rw mul_comm
+                   ... = (2^m*2^(m*n) - 2^m*1)/2^m + 1  : by simp
+                   ... = 2^m*(2^(m*n) - 1)/2^m + 1      : by rw ←nat.mul_sub_left_distrib
+                   ... = (2^(m*n) - 1)*2^m/2^m + 1      : by rw mul_comm
+                   ... = (2^(m*n) - 1) + 1              : by rw (nat.mul_div_left _ pow_two_pos)
+                   ... = 2^(m*n) - 1 + 1                : by simp
+                   ... = 2^(m*n)                        : nat.sub_add_cancel two_pow_mn_big
+
+  end
+
+lemma le_of_add_right {n m : ℕ}
+  : n + m ≥ m :=
+  begin
+    apply le_add_of_nonneg_left,
+    apply zero_le,
+  end
+
+lemma le_of_add_left {n m : ℕ}
+  : n + m ≥ n :=
+  begin
+    apply le_add_of_nonneg_right,
+    apply zero_le,
+  end
+
+@[simp]
+lemma min_add_eq_right {n m : ℕ}
+  : min (n + m) m = m :=
+  begin
+    apply min_eq_right,
+    apply le_of_add_right,
+  end
+
+@[simp]
+lemma min_add_eq_left {n m : ℕ}
+  : min (n + m) n = n :=
+  begin
+    apply min_eq_right,
+    apply le_of_add_left,
+  end
+
+lemma div_left {x y z k : ℕ} (H: k > 0) (Hlt: x < z * k)
+  : x / k < (z * k) / k :=
+  begin
+    intros,
+    rw (div_lt_iff_lt_mul _ _ H),
+    rw mul_div_left _ H,
+    assumption,
+  end
+
+lemma div_of_pow_two_lt_pow_add {n m x : ℕ} (h: x < 2^(m * succ n))
+  : x/2^m < 2^(m*n) :=
+  begin
+    have two_pos: 0 < 2, dec_trivial_tac,
+    have pow_m_pos: 0 < 2^m,
+    { apply pos_pow_of_pos _ two_pos, },
+    have: 2^(m * succ n) = 2^(m*n) * 2^m,
+    { rw [←add_one, left_distrib], simp,
+      rw [add_comm, pow_distrib],
+    },
+    have: x < 2^(m*n) * 2^m,
+    { rwa this at h,
+    },
+    rwa ←div_lt_iff_lt_mul x (2^(m*n)) pow_m_pos at this,
+  end
+
+lemma mod_div_of_pow_two_eq {n m x : ℕ} (h: x < 2^(m * succ n))
+  : x % 2 ^ m + x / 2 ^ m % 2 ^ (m * n) * 2 ^ m = x :=
+  begin
+    have: x/2^m < 2^(m*n),
+    { exact div_of_pow_two_lt_pow_add h, },
+    rw [mod_eq_of_lt this],
+    rw [mul_comm],
+    rw mod_add_div,
+  end
+
+lemma gt_of_not_zero {n:ℕ}
+  : (¬n = 0) → n > 0 :=
+  begin
+    intro h,
+    cases n,
+    case nat.zero
+    { exfalso, apply h, refl },
+    case nat.succ
+    { apply nat.zero_lt_succ },
+  end
+
+lemma lt_div_pow {x n m : ℕ} (H: x < 2^(n + m))
+  : x / 2 ^ m < 2 ^ n :=
+  begin
+    have: 2^m > 0,
+    { apply pos_pow_of_pos, dec_trivial_tac },
+    rw div_lt_iff_lt_mul x (2^n) this,
+    rw [←pow_distrib],
+    exact H
+  end
+
+lemma pow_mod_superfluous' {x n m : ℕ} (H : x < 2^(n + m))
+  : x / 2 ^ m % 2 ^ n = x / 2^m :=
+  begin
+    apply mod_eq_of_lt,
+    apply lt_div_pow H,
+  end
+
+lemma lt_of_mul {n m k : ℕ}
+  : k > 0 → n < m → n < m * k :=
+  begin
+    intros,
+    cases k,
+    { cases a, },
+    { intros,
+      rw [succ_eq_add_one, left_distrib],
+      simp,
+      apply (nat.lt_add_right _ _ _ a_1),
+    },
+  end
+
+lemma shiftr_mono {n m k : ℕ} (H: n < m)
+  : nat.shiftr n k < m :=
+  begin
+    have : 0 < 2^k,
+    { apply pos_pow_of_pos,
+      dec_trivial_tac
+    },
+    rw [shiftr_eq_div_pow, div_lt_iff_lt_mul _ _ this],
+    apply lt_of_mul this H,
+  end
+
+lemma add_pow_bound {c v k n : ℕ} (Hc: c < 2^(k*n)) (Hv: v < 2^n)
+  : c + v * 2^(k*n) < 2^((k + 1) * n) :=
+  begin
+    calc
+    c + v * 2^(k*n) < 2^(k*n) + v * 2^(k*n) : by apply nat.add_lt_add_right Hc
+                ... = (v + 1) * 2^(k*n)     : by simp [right_distrib]
+                ... ≤ 2^n * 2^(k*n)         : begin apply (nat.mul_le_mul_right), apply (nat.succ_le_of_lt Hv) end
+                ... = 2^((k+1) * n)         : begin simp [pow_distrib, right_distrib], end
+  end


### PR DESCRIPTION
Thanks for your patience with this refactor. I think it's finally ready for feedback.

Refactors and cleanups:

  * Add a new module, list.lemmas, for additional lemmas on lists.
  * Simplifies `trunc` (and friends) to use addition in the type instead of `min`
  * Adds new functions:
    * bsf, index of least-significant 1 bit
    * bsr, index of most-significant 1 bit
    * split_at, splits a bit vector at an index
    * chunks, splits a bitvector into smaller chunks (note: the bit
    order may not be what you expect)
    * concat, joins a list of bitvectors together
    * chunks_nat, splits a nat into a list of bitvectors, order has the
    most siginificant bit at the head of the list.
    * chunks', which is chunks_nat lifted to bitvector
    * concat_nat, like concat but returns a nat.
    * slice, for taking a slice of a bitvector
  * Several new lemmas for the definitions mentioned above
  * New convenience lemmas for natural numbers.

One big caveat, is that there is still an unfinished proof. The proof that `concat_nat` of `chunks_nat` gives  you back the original number up to `mod` is not finished. I reduced the goal down to just arithmetic ops, that might make a good lemma but I don't have any intuition for proving it.

`chunks` returns the chunks in the reverse of the order that you probably want them (least-significant at the head of the list), but I was able to prove the corresponding `concat/chunks` lemma so I've left that version in for now.