### PR TITLE
add g++ install to vagrant provision script

### DIFF
--- a/scripts/1-host-provision.sh
+++ b/scripts/1-host-provision.sh
@@ -8,6 +8,7 @@ sudo apt-get update
 sudo apt-get install -y binutils
 
 # For repo build
+sudo apt install -y g++
 sudo apt install -y make cmake libgmp-dev zlib1g-dev
 sudo apt install -y llvm-8
 sudo apt install -y llvm-8-dev


### PR DESCRIPTION
Poking around trying to get things set up, I noticed the Travis CI script used the following to install things:

```
./scripts/build-lean4.sh lean4/deps/lean4 build/lean4 local llvm-config-8 -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
```

So I went with that and discovered `g++` isn't already installed via the Vagrant script, hence this PR.

Please advise if I'm off in la la land here ;-)