### PR TITLE
fix git submodule names (make them consistent)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "lean4"]
+[submodule "lean4/deps/lean4"]
 	path = lean4/deps/lean4
 	url = git@github.com:leanprover/lean4.git
 [submodule "lean4/deps/lean-llvm"]


### PR DESCRIPTION
I was unable to clone the repo and it's submodules after
commit 9990364a76601a2afab04dac3f08a625cf9495ab. Specifically,
`git submodule update --init` would fail after cloning (with the
same error message appearing on TravisCI for commit
c7fc395373e69891a03312a6a8066c2781aa6fbe). I noticed the
lean4 git submodule used the name `lean4` while the lean-llvm
submodule used the name `lean4/deps/lean-llvm`. Changing _either_
subomdule's name in the `.gitmodules` file so they were of a
consistent style (i.e., either both just the repo name or both
the paths to the repo) seemed to fix the problem.