### PR TITLE
tweaks to Makefile to consistently generate target names and paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,5 +56,5 @@ script:
 
   # Build the semantics binary
   - pushd lean4
-  - LEAN_CXX=clang-8 make LEAN=$PWD/../local/bin/lean LEANC=$PWD/../local/bin/leanc LLVM_CONFIG=llvm-config-8 CXX=clang-8
+  - travis_wait 30 make LEAN_CXX=clang-8 LEAN=$PWD/../local/bin/lean LEANC=$PWD/../local/bin/leanc LLVM_CONFIG=llvm-config-8 CXX=clang-8
   - popd

--- a/lean4/Makefile
+++ b/lean4/Makefile
@@ -1,20 +1,44 @@
 
 # http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/#tldr
 
-# DEPDIR := .d
-# $(shell mkdir -p $(DEPDIR) >/dev/null)
+# IMPORTANT:
+#
+# 1. Please AVOID DOUBLE SLASHES (e.g., `//`) and other seemingly
+#    innocuous but unneccesary content in generated file paths;
+#
+# 2. Please do not leave trailing slashes on directory paths---e.g.,
+#    use `foo/bar/baz` and not `foo/bar/baz/`---to help achieve (1).
+#
+# This Makefile and the included `Makefile.include`s must be careful
+# to consistently name paths/files/etc since we _generate_ makefile
+# rules/dependencies/etc based on these values which then impact the
+# build. While the double slashes, dot-dots, etc may be
+# ignored/removed/etc in many cases, when used as a target name a path
+# with that sort of extra "noise" in it will _not_ be considered the
+# same target as the same path without such seemingly innocuous noise.
 
-SRCROOT := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
+
+# Determine the root directory for the source files (e.g., `.../reopt-vcg/lean4`)
+SRCROOT := $(abspath $(dir $(realpath $(firstword $(MAKEFILE_LIST)))))
+# A lowercase version of SRCROOT used below (AMK: TODO why are we doing this?)
 LCSRCROOT := $(shell echo ${SRCROOT} | tr A-Z a-z)
 
+# Where do we put the build files?
 BUILDDIR ?= build
 # $(shell mkdir -p $(DEPDIR) >/dev/null)
 
+# Names of the Lean executables if they're not explicitly
+# set already defined already in the environment
 LEAN ?= lean
 LEANC ?= leanc
 
-LEANDIR := ${dir ${shell which ${LEAN}}}../
+# Up one directory from the executable we should be able to find
+# the `lib` directory with Lean files in it
+LEANDIR := ${realpath ${dir ${shell which ${LEAN}}}/..}
 
+
+# Set the Lean Path (i.e., the key-value pairs of Lean packages and their locations)
+# to include the Init definitions from Lean
 LEAN_PATH := Init=${LEANDIR}/lib/lean/Init
 
 # This forces LEANFILES to be strict
@@ -32,14 +56,19 @@ include deps/lean-llvm/Makefile.include
 include deps/x86_semantics/Makefile.include
 include simulator/Makefile.include
 
-#LEANFILES are absolute, we need them to be relative to the root dir for the rest to work.
-LEANFILES_REL := ${patsubst ${SRCROOT}%,%,${LEANFILES}}
-EXTRAOBJ      := ${patsubst ${SRCROOT}%.cpp,${BUILDDIR}/%.o,${EXTRACXXFILES}}
 
-DEPENDS := ${patsubst %.lean,%.d,${LEANFILES_REL}}
-OLEAN   := ${patsubst %.lean,%.olean,${LEANFILES_REL}}
-CPPLEAN := ${patsubst %.lean,$(BUILDDIR)/%.cpp,${LEANFILES_REL}}
+# The paths populating LEANFILES from the various above includes are absolute,
+# but we need them to be relative to the root dir for the rest to work.
+LEANFILES_REL := ${patsubst ${SRCROOT}/%,%,${LEANFILES}}
+EXTRAOBJFILES := ${patsubst ${SRCROOT}/%.cpp,${BUILDDIR}/%.o,${EXTRACXXFILES}}
 
+# For every Lean file `Foo.lean` there should be a `Foo.d` with an entry
+# `Foo.c Foo.olean: DEPENDENCY1.olean ... DEPENDENCYN.olean` describing the
+# N files that lean file depends on
+DEPFILES := ${patsubst %.lean,%.d,${LEANFILES_REL}}
+
+OLEANFILES   := ${patsubst %.lean,%.olean,${LEANFILES_REL}}
+CPPLEANFILES := ${patsubst %.lean,$(BUILDDIR)/%.cpp,${LEANFILES_REL}}
 
 
 # FIXME: move to llvm-tablegen-support submake
@@ -52,26 +81,22 @@ CXXFLAGS += -fPIC -ggdb3
 
 export LEAN_PATH
 
-MAKEDEPEND = $(LEAN) --deps $< | sed 's@${LCSRCROOT}@@p' | xargs echo "$(BUILDDIR)/$*.cpp $*.olean:" > $@
+MAKEDEPEND = $(LEAN) --deps $< | sed 's@${LCSRCROOT}/@@p' | sort -u | xargs echo "$(BUILDDIR)/$*.cpp $*.olean:" > $@
 
-depend: ${DEPENDS}
 
-$(BUILDDIR)/sim : ${CPPLEAN} ${EXTRAOBJ} build/simulator/Main.cpp
+depend: ${DEPFILES}
+
+$(BUILDDIR)/sim : ${CPPLEANFILES} ${EXTRAOBJFILES} build/simulator/Main.cpp
 	${LEANC} ${CXXFLAGS} `${LLVM_CONFIG} --cxxflags` -Wno-variadic-macros -Wno-gnu-zero-variadic-macro-arguments  -fexceptions -o $@ $^ `${LLVM_CONFIG} --ldflags --system-libs --libs x86` -lstdc++
 
-$(BUILDDIR)/driver: ${CPPLEAN} ${EXTRAOBJ} build/deps/lean-llvm/src/Driver.cpp
+$(BUILDDIR)/driver: ${CPPLEANFILES} ${EXTRAOBJFILES} build/deps/lean-llvm/src/Driver.cpp
 	${LEANC} ${CXXFLAGS} `${LLVM_CONFIG} --cxxflags` -Wno-variadic-macros -Wno-gnu-zero-variadic-macro-arguments  -fexceptions -o $@ $^ `${LLVM_CONFIG} --ldflags --system-libs --libs x86` -lstdc++
 
 %.d: %.lean
 	$(MAKEDEPEND)
 
-
-# The olean have to be in the same directory :/
-# %.olean : %.lean
-# 	$(LEAN) --make $<
-
 # could do this when making the olean
-$(BUILDDIR)/%.cpp %.olean: %.lean 
+$(BUILDDIR)/%.cpp %.olean: %.lean
 	@mkdir -p ${dir $(BUILDDIR)/$*.cpp}
 	$(LEAN) --cpp="$(BUILDDIR)/$*.cpp.tmp" --make $<
 	mv $(BUILDDIR)/$*.cpp.tmp $(BUILDDIR)/$*.cpp
@@ -86,26 +111,10 @@ $(BUILDDIR)/deps/llvm-tablegen-support/src/%: CXXFLAGS += -g -O3 -I deps/llvm-ta
 
 $(BUILDDIR)/deps/lean-llvm/src/%: CXXFLAGS += -g -O3 -I deps/llvm-tablegen-support/src/ -I deps/llvm-tablegen-support/llvm-files/ `${LLVM_CONFIG} --cxxflags` -I${LEANDIR}/include/ -I${LEANDIR}/include/runtime -std=c++14 -fexceptions
 
-# %.olean %.cpp : %.lean %.d
-# 	@mkdir -p $(@D);
-#         @$(LEAN) --deps $< > $*.Td; \
-#           cp $*.Td $*.d; \
-#           sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
-#               -e '/^$$/ d' -e 's/$$/ :/' < $*.Td >> $*.d; \
-#           rm -f $*.Td
-#         $(LEAN) --make --cpp="$*.cpp.tmp" $<
-# # create the .cpp file atomically
-#         @mv "$*.cpp.tmp" "$*.cpp"
-# 	@touch $*.olean
 
-# # %.o : %.cpp
-# # %.o : %.cpp
 
-# %.d: ;
-# .PRECIOUS: %.d
-
-# include $(wildcard $(patsubst %,%.d,$(basename $(SRCS))))
 clean:
-	rm -f ${DEPENDS} ${OLEAN}
+	rm -f ${DEPFILES} ${OLEANFILES}
 
-include ${DEPENDS}
+
+include ${DEPFILES}

--- a/lean4/Makefile
+++ b/lean4/Makefile
@@ -20,8 +20,6 @@
 
 # Determine the root directory for the source files (e.g., `.../reopt-vcg/lean4`)
 SRCROOT := $(abspath $(dir $(realpath $(firstword $(MAKEFILE_LIST)))))
-# A lowercase version of SRCROOT used below (AMK: TODO why are we doing this?)
-LCSRCROOT := $(shell echo ${SRCROOT} | tr A-Z a-z)
 
 # Where do we put the build files?
 BUILDDIR ?= build
@@ -81,7 +79,7 @@ CXXFLAGS += -fPIC -ggdb3
 
 export LEAN_PATH
 
-MAKEDEPEND = $(LEAN) --deps $< | sed 's@${LCSRCROOT}/@@p' | sort -u | xargs echo "$(BUILDDIR)/$*.cpp $*.olean:" > $@
+MAKEDEPEND = $(LEAN) --deps $< | sed 's@${SRCROOT}/@@p' | sort -u | xargs echo "$(BUILDDIR)/$*.cpp $*.olean:" > $@
 
 
 depend: ${DEPFILES}

--- a/lean4/deps/galois_stdlib/Makefile.include
+++ b/lean4/deps/galois_stdlib/Makefile.include
@@ -1,8 +1,8 @@
 
-HERE := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+HERE := $(abspath $(dir $(realpath $(lastword $(MAKEFILE_LIST)))))
 LOCAL_LLVM := src/Galois/Data/Bitvec.lean  src/Galois/Init/Int.lean src/Galois/Init/Io.lean src/Galois/Init/Nat.lean src/Galois/Category/Coe1.lean \
               src/Galois/Data/ParserComb.lean
 LOCAL_CXX  := src/Galois/Init/io_runtime.cpp
-LEANFILES += $(patsubst %,${HERE}%,${LOCAL_LLVM})
-EXTRACXXFILES += $(patsubst %,${HERE}%,${LOCAL_CXX})
-LEAN_PATH := ${LEAN_PATH}:Galois=${HERE}src/Galois
+LEANFILES += $(patsubst %,${HERE}/%,${LOCAL_LLVM})
+EXTRACXXFILES += $(patsubst %,${HERE}/%,${LOCAL_CXX})
+LEAN_PATH := ${LEAN_PATH}:Galois=${HERE}/src/Galois

--- a/lean4/deps/llvm-tablegen-support/Makefile.include
+++ b/lean4/deps/llvm-tablegen-support/Makefile.include
@@ -1,9 +1,9 @@
 
-HERE := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+HERE := $(abspath $(dir $(realpath $(lastword $(MAKEFILE_LIST)))))
 LOCAL_LLVM := lean/DecodeX86.lean
 LOCAL_CXX  := src/Metadata.cpp src/lean_support.cpp src/X86Disassembler.cpp
 
-LEANFILES += $(patsubst %,${HERE}%,${LOCAL_LLVM})
-EXTRACXXFILES += $(patsubst %,${HERE}%,${LOCAL_CXX})
-LEAN_PATH := ${LEAN_PATH}:DecodeX86=${HERE}lean/
+LEANFILES += $(patsubst %,${HERE}/%,${LOCAL_LLVM})
+EXTRACXXFILES += $(patsubst %,${HERE}/%,${LOCAL_CXX})
+LEAN_PATH := ${LEAN_PATH}:DecodeX86=${HERE}/lean
 

--- a/lean4/deps/x86_semantics/Makefile.include
+++ b/lean4/deps/x86_semantics/Makefile.include
@@ -1,5 +1,5 @@
 
-HERE := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+HERE := $(abspath $(dir $(realpath $(lastword $(MAKEFILE_LIST)))))
 LOCALFILES := src/X86Semantics/BufferMap.lean src/X86Semantics/Common.lean src/X86Semantics/Evaluator.lean src/X86Semantics/Instructions.lean src/X86Semantics/MachineMemory.lean
-LEANFILES += $(patsubst %,${HERE}%,${LOCALFILES})
-LEAN_PATH := ${LEAN_PATH}:X86Semantics=${HERE}src/X86Semantics
+LEANFILES += $(patsubst %,${HERE}/%,${LOCALFILES})
+LEAN_PATH := ${LEAN_PATH}:X86Semantics=${HERE}/src/X86Semantics

--- a/lean4/simulator/Makefile.include
+++ b/lean4/simulator/Makefile.include
@@ -1,6 +1,6 @@
 
-HERE := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+HERE := $(realpath $(dir $(realpath $(lastword $(MAKEFILE_LIST)))))
 LOCALFILES := Elf.lean Runelf.lean Translate.lean
-LEANFILES += $(patsubst %,${HERE}%,${LOCALFILES})
-LEAN_PATH := ${LEAN_PATH}:Main=${HERE}/
+LEANFILES += $(patsubst %,${HERE}/%,${LOCALFILES})
+LEAN_PATH := ${LEAN_PATH}:Main=${HERE}
 

--- a/scripts/build-lean4.sh
+++ b/scripts/build-lean4.sh
@@ -26,6 +26,10 @@ cmake $SRCDIR/src -DCMAKE_BUILD_TYPE=debug -DCMAKE_INSTALL_PREFIX=$INSTALLDIR -D
 make -j16
 make install
 popd
+
+mkdir -p $INSTALLDIR/include/util
+cp $SRCDIR/src/util/buffer.h $INSTALLDIR/include/util/
+
 # ninja install
 # rm -f $HOME/opt/lean4
 # ln -s $HOME/opt/lean4-$GITREV/ $HOME/opt/lean4


### PR DESCRIPTION
+ commit 8103e1c adds a few commands to the `build-lean4.sh` script to copy some C source files from the Lean directory to the build site which are later needed for compilation. (Note, this may become superfluous in the near future once we update the Lean4 submodule again, but for now it seems useful to get our CI working.)

+ commit 50a0e12 tries to consistently generate paths and target names in Makefiles across the code base to solve an issue we were having with ignored dependencies in the build: 

In particular, previously it appeared the Makefile was ignoring some of the auto-generated dependencies we rely on for builds to work. It seems when we're doing this sort of `make` "meta-programming"---where we intend to use the Makefile to dynamically generate additional Makefile content which will then be included back into the Makefile---we have to take care to be consistent with file paths which could end up as target names since make will consider `foo/bar` and `foo//bar` to be two _different_ build targets even though they're treated in most other cases as referring to the same file path. (See someone else complaining about this [here](https://stackoverflow.com/questions/34489191/double-slashes-in-paths-in-makefile), for example.)