### PR TITLE
parsing complete, precondition SMT generation needs a little attention

### DIFF
--- a/lean4/app/SMTParser.lean
+++ b/lean4/app/SMTParser.lean
@@ -1,14 +1,22 @@
+import Galois.Data.RBMap
 import Galois.Data.SExp
 import SMTLIB.Syntax
+import LeanLLVM.AST
+import X86Semantics.Common
 
 namespace ReoptVCG
 
-universe u
+section
+universes u v
+
+
+open WellFormedSExp
+open SMT
 
 ------------------------------------------------------------------------
 -- Expression
 
-inductive Atom
+inductive Atom : Type u
 | nat : Nat → Atom
 | ident : String → Atom 
 
@@ -22,14 +30,12 @@ def readAtom (str : String) : Except String Atom :=
 if str.isEmpty
 then Except.error "an Atom must contain one or more characters"
 else
-  let subStr := str.toSubstring;
-  match subStr.toNat? with
+  match str.toSubstring.toNat? with
   | some n => pure $ Atom.nat n
   | none => pure $ Atom.ident str
 
-abbrev SExpr := WellFormedSExp.SExp Atom
 
-def readSExpr (str:String) : Except String SExpr := do
+def readSExp (str:String) : Except String (SExp Atom) := do
 ss ← WellFormedSExp.SExp.readSExps readAtom str;
 match ss with
 | [] => Except.error "no s-expressions were found in the string"
@@ -37,34 +43,204 @@ match ss with
 | _ => Except.error $ "multiple s-expressions were found in the string: " ++ str
 
 
--- TODO / FIXME Should we just use the typed SMT expression AST from the
--- lean SMTLIB? Or is this `Expr` here useful as we just want to reason
--- about a subset or similar?
+inductive AddrWidth
+| w8  : AddrWidth
+| w16 : AddrWidth
+| w32 : AddrWidth
+| w64 : AddrWidth
 
-/-- An expression in the SMT bitvector theory.
+namespace AddrWidth
 
-   The type `α` allows one to create holes for
-   variables or other known constants. --/
-inductive Expr (α : Type u)
-| eq    : Expr → Expr → Expr
-| bvAdd : Expr → Expr → Expr
-| bvSub : Expr → Expr → Expr
+def toNat : AddrWidth → Nat
+| w8  => 8
+| w16 => 16
+| w32 => 32
+| w64 => 64
+
+def fromNat : Nat → Option AddrWidth
+| 8  => some w8
+| 16 => some w16
+| 32 => some w32
+| 64 => some w64
+| _  => none
+
+end AddrWidth
+
+/-- An expression in the SMT bitvector theory with 
+    variables/constants which may appear in 
+    block preconditions. --/
+inductive BlockExpr : sort → Type u
+| stackHigh : BlockExpr sort.bv64
+  -- ^ Denotes the high address on the stack.
+  --
+  -- This is the address the return address is stored at, and
+  -- the curent frame.
+| initGPReg64 : x86.reg64 → BlockExpr sort.bv64
+  -- ^ Denotes the value of a 64-bit general purpose register
+  -- at the start of the block execution.
+| fnStartGPReg64 : x86.reg64 → BlockExpr sort.bv64
+  -- ^ Denotes the value of a general purpose when the function starts.
+  --
+  -- Note. We do not support all registers here, only the registers
+  -- in `calleeSavedGPRegs`
+| mcStack (a : BlockExpr sort.bv64) (w:AddrWidth) : BlockExpr (sort.bitvec w.toNat)
+  -- ^ @MCStack a w@ denotes @w@-bit value stored at the address @a@.
+  --
+  -- The width @w@ should be @8@, @16@, @32@, or @64@.
+  --
+  -- Our memory model only tracks the mc-only variables, so if the
+  -- address is not a stack-only variable, then the value just
+  -- means some arbitrary value.
+| llvmVar (nm : String) (tp : sort) : BlockExpr tp
+  -- ^ This denotes the value of an LLVM Phi variable when the
+  -- block starts.
+| eq    {tp : sort} : BlockExpr tp → BlockExpr tp → BlockExpr sort.smt_bool
+| bvAdd {n : Nat} : BlockExpr (sort.bitvec n) → BlockExpr (sort.bitvec n) → BlockExpr (sort.bitvec n)
+| bvSub {n : Nat} : BlockExpr (sort.bitvec n) → BlockExpr (sort.bitvec n) → BlockExpr (sort.bitvec n)
   -- | @BVDecimal v w@ denotes the @w@-bit value @v@ which should
-  -- satisfy the property that @v < s^w@.
-| bvDecimal : Nat -> Nat -> Expr
-| atom : α -> Expr
+  -- satisfy the property that @v < 2^w@.
+| bvDecimal (v w : Nat) : BlockExpr (sort.bitvec w)
 
-def VarParser (α : Type u) := SExpr -> Except String (α × SMT.sort)
+/-- Map from LLVM ident names to their sorts--/
+abbrev LLVMTyEnv := RBMap llvm.ident SMT.sort (λ x y => x<y)
 
--- was simply `fromText` in Haskell
-def Expr.fromString
-{α : Type u}
-(varParser : VarParser α)
-(input : String) : Except String (Expr α) :=
-Except.error "TODO: implement Expr.fromString"
+namespace BlockExpr
 
-def evalExpr {α : Type u} : VarParser α → SExpr → Except String ((Expr α) × SMT.sort) :=
-λ varParser input => Except.error "TODO: implement readExpr"
+private def ppLLVMIdent : llvm.ident → String
+| llvm.ident.named nm => nm
+| llvm.ident.anon n => n.repr
 
+-- was `evalExpr`
+partial def fromSExp
+(llvmTyEnv : LLVMTyEnv)
+: (SExp Atom) → Except String (Sigma BlockExpr)
+| SExp.list [SExp.atom (Atom.ident "="), x, y] => do
+  ⟨xtp, xe⟩ ← fromSExp x;
+  ⟨ytp, ye⟩ ← fromSExp y;
+  if h : (xtp = ytp)
+  then 
+    let hEq : BlockExpr xtp = BlockExpr ytp := h ▸ rfl;
+    Except.ok ⟨sort.smt_bool, eq (cast hEq xe) ye⟩
+  else Except.error $ 
+       "The two operands in the term `"
+       ++ (SExp.list [SExp.atom (Atom.ident "="), x, y]).toString
+       ++ "` must have the same type, but the first"
+       ++ " was of type " ++ xtp.toString
+       ++ " and the second was of type " ++ ytp.toString
+| SExp.list [SExp.atom (Atom.ident "bvsub"), x, y] => do
+  xRes ← fromSExp x;
+  yRes ← fromSExp y;
+  match xRes, yRes with
+  | ⟨sort.bitvec xw, xe⟩, ⟨sort.bitvec yw, ye⟩ =>
+    if h : xw = yw
+    then 
+      let hEq : BlockExpr (sort.bitvec xw) = BlockExpr (sort.bitvec yw) := h ▸ rfl;
+      Except.ok ⟨sort.bitvec yw, bvSub (cast hEq xe) ye⟩
+    else Except.error $ 
+         "The two operands in the term `"
+          ++ (SExp.list [SExp.atom (Atom.ident "bvsub"), x, y]).toString
+          ++ "` must both be bitvectors of the same length, but the first"
+          ++ " was of length " ++ xw.repr
+          ++ " and the second was of length " ++ yw.repr
+  | ⟨xtp, xe⟩, ⟨ytp, ye⟩ => 
+    Except.error $ "The two operands in the term `"
+    ++ (SExp.list [SExp.atom (Atom.ident "bvsub"), x, y]).toString
+    ++ "` must both be bitvectors of the same length, but the first"
+    ++ " was of type " ++ xtp.toString
+    ++ " and the second was of type " ++ ytp.toString
+| (SExp.list [SExp.atom (Atom.ident "_"), SExp.atom (Atom.ident bvLit), SExp.atom (Atom.nat width)]) =>
+  match bvLit.data with
+  | 'b'::'v'::nChars =>
+    let nStr := nChars.asString;
+    match nStr.toSubstring.toNat? with
+    | some n => 
+      let val : Nat := Nat.land n $ (Nat.pow 2 width) - 1;
+      Except.ok ⟨sort.bitvec width, bvDecimal val width⟩
+    | none => Except.error $ "a bitvector literal should have a natural number adjacent to `bv`"
+              ++ " but found " ++ bvLit
+  | _ => Except.error $ "unrecognized SMT expression: " ++ bvLit
+| SExp.list [SExp.atom (Atom.ident "mcstack"), sa, sw] => do
+  ⟨tp, a⟩ ← fromSExp sa;
+  if h : tp = sort.bv64
+  then do
+    let hEq : BlockExpr tp = BlockExpr sort.bv64 := h ▸ rfl;
+    w ← match sw with
+        | SExp.list [SExp.atom (Atom.ident "_"),
+                     SExp.atom (Atom.ident "BitVec"),
+                     SExp.atom (Atom.nat w)] =>
+          match AddrWidth.fromNat w with
+          | some width => Except.ok width
+          | none => Except.error "mcstack could not interpret memory type."
+        | _ => Except.error "mcstack could not interpret memory type";
+    Except.ok ⟨sort.bitvec w.toNat, BlockExpr.mcStack (cast hEq a) w⟩
+  else
+    Except.error $ "Expected 64-bit address as first argument to mcstack"
+                   ++ " but found a " ++ tp.toString
+| SExp.list [SExp.atom (Atom.ident "fnstart"), regExpr] =>
+  match regExpr with
+  | SExp.atom (Atom.ident regName) =>
+    match x86.reg64.fromName regName with
+    | some r => Except.ok ⟨sort.bv64, BlockExpr.fnStartGPReg64 r⟩
+    | none => Except.error $ "could not interpret register name " ++ regName
+  | _ => Except.error $ "could not interpret register name " ++ regExpr.toString
+| SExp.list [SExp.atom (Atom.ident "llvm"), llvmExpr] =>
+  match llvmExpr with
+  | SExp.atom (Atom.ident llvmName) =>
+    match llvmTyEnv.find? (llvm.ident.named llvmName) with
+    | some tp => Except.ok ⟨tp, BlockExpr.llvmVar llvmName tp⟩
+    | none => Except.error $ "Could not interpret llvm variable " ++ llvmExpr.toString
+                           ++ "\nKnown variables: " ++ (llvmTyEnv.keys.map ppLLVMIdent).toString
+  | _ => Except.error $ "Could not interpret llvm variable " ++ llvmExpr.toString
+                      ++ "\nKnown variables: " ++ (llvmTyEnv.keys.map ppLLVMIdent).toString
+| SExp.atom (Atom.ident "stack_high") =>
+  Except.ok ⟨sort.bv64, BlockExpr.stackHigh⟩
+| SExp.atom (Atom.ident nm) =>
+  match x86.reg64.fromName nm with
+  | some r => Except.ok ⟨sort.bv64, BlockExpr.initGPReg64 r⟩
+  | none => Except.error $ "Could not interpret identifier as a variable: " ++ nm
+| sexpr => Except.error $ "Could not interpret expression: " ++ sexpr.toString
+
+
+-- was simply `fromText` in Haskell, was a moment ago in lean4 `Expr.fromString`
+def parseAs
+(tp : sort)
+(llvmTyEnv : LLVMTyEnv)
+(input : String)
+: Except String (BlockExpr tp) := do
+⟨tp', e⟩ ← readSExp input >>= fromSExp llvmTyEnv;
+if h : tp' = tp
+then 
+  let hEq : BlockExpr tp' = BlockExpr tp := h ▸ rfl;
+  Except.ok $ cast hEq e
+else Except.error $ "expected " ++ input ++ " to be of type " ++ tp.toString
+                  ++ ", but it is of type " ++ tp'.toString
+
+
+def typedNameToSMT (tp : sort) (nm : String) : term tp :=
+Raw.term.identifier $ Raw.identifier.symbol (Raw.const_sort.base tp) nm
+
+-- Converts an Expr into an SMT expression. See `encodeExpr` and `exprToText` in
+-- the Haskell.
+def toSMT : ∀ {tp : sort}, BlockExpr tp → term tp
+-- encodeVar StackHigh = "stack_high"
+| tp, stackHigh => typedNameToSMT tp "stack_high" -- TODO check if this is right
+-- encodeVar (InitGPReg64 r) = fromString (show r)
+| tp, initGPReg64 r => typedNameToSMT tp r.name -- TODO check if this is right
+-- encodeVar (FnStartGPReg64 r) = encodeList ["fnstart", fromString (show r)]
+| tp, fnStartGPReg64 r => typedNameToSMT tp "TODO: toSMT fnstart"
+-- encodeVar (MCStack e w) =
+--  let tp = encodeList ["_", "BitVec", fromString (show w)]
+--   in encodeList ["mcstack", encodeExpr e, tp]
+| tp, mcStack a w => typedNameToSMT tp "TODO: toSMT mcStack"
+-- encodeVar (LLVMVar nm) = encodeList ["llvm", sexprFromText nm]
+| _, llvmVar nm tp => typedNameToSMT tp "TODO: toSMT llvmVar"
+| _, eq e1 e2 => SMT.eq (toSMT e1) (toSMT e2)
+| _, bvAdd e1 e2 => SMT.bvadd (toSMT e1) (toSMT e2)
+| _, bvSub e1 e2 => SMT.bvsub (toSMT e1) (toSMT e2)
+| _, bvDecimal n width => SMT.bvimm width n
+
+end BlockExpr
+
+end
 
 end ReoptVCG

--- a/lean4/app/Types.lean
+++ b/lean4/app/Types.lean
@@ -248,7 +248,7 @@ def BlockLabelValMap := RBMap llvm.block_label llvm.value (λ x y => x < y)
 structure AnnotatedBlock :=
 (annotation: BlockAnn)
 (label : llvm.block_label)
-(phiVarMap : RBMap llvm.ident (SMT.sort × BlockLabelValMap) (λ x y => x<y))
+(phiVarMap : RBMap llvm.ident (llvm.llvm_type × BlockLabelValMap) (λ x y => x<y))
 (stmts : List llvm.stmt)
 
 

--- a/lean4/deps/galois_stdlib/src/Galois/Data/RBMap.lean
+++ b/lean4/deps/galois_stdlib/src/Galois/Data/RBMap.lean
@@ -1,13 +1,22 @@
 
 namespace RBMap
 universes u v w
-variables {α : Type u} {β : Type v} {σ : Type w} {lt : α → α → Bool}
+variables {α : Type u} {β : Type v}
+
+/-- Builds an RBMap from a list with String keys. --/
+def ltMap [HasLess α] [∀ (a b : α), Decidable (a < b)] (entries: List (α × β))
+ : RBMap α β (λ (x y:α)=> x<y) :=
+RBMap.fromList entries (λ (x y:α)=> x<y)
+
+
+section
+variable {lt : α → α → Bool}
 
 @[specialize] def keys : RBMap α β lt → List α
 | ⟨t, _⟩ => t.revFold (fun ps k _v => k::ps) []
 
 @[specialize] def values : RBMap α β lt → List β
 | ⟨t, _⟩ => t.revFold (fun ps _k v => v::ps) []
-
+end
 
 end RBMap

--- a/lean4/deps/galois_stdlib/src/Galois/Data/SExp.lean
+++ b/lean4/deps/galois_stdlib/src/Galois/Data/SExp.lean
@@ -40,8 +40,6 @@ Except.error $ "Failed to parse s-expression: " ++ specific ++ "."
 
 private def revStr (c:Char) (cs:List Char) : String := (c::cs).reverse.asString
 
-private def isDelim (c:Char) : Bool := c.isWhitespace || c == '(' || c == ')'
-
 
 def readAux {α : Type u} (parseAtom : String → Except String α) :
 List Char →

--- a/lean4/deps/smtlib/src/SMTLIB/Syntax.lean
+++ b/lean4/deps/smtlib/src/SMTLIB/Syntax.lean
@@ -53,6 +53,29 @@ def bv16 := bitvec 16
 def bv32 := bitvec 32
 def bv64 := bitvec 64
 
+
+protected def hasDecEq : ∀(a b : sort), Decidable (a = b)
+| smt_bool, bitvec _ => isFalse (λ h => sort.noConfusion h)
+| smt_bool, array _ _ => isFalse (λ h => sort.noConfusion h)
+| bitvec _, smt_bool => isFalse (λ h => sort.noConfusion h)
+| bitvec _, array _ _ => isFalse (λ h => sort.noConfusion h)
+| array _ _, bitvec _ => isFalse (λ h => sort.noConfusion h)
+| array _ _, smt_bool => isFalse (λ h => sort.noConfusion h)
+| smt_bool, smt_bool => isTrue rfl
+| bitvec x, bitvec y => 
+  match decEq x y with
+  | isTrue hxy => isTrue (Eq.subst hxy rfl)
+  | isFalse nxy => isFalse (λ h => sort.noConfusion h (λ hxy => absurd hxy nxy))
+| array a b, array c d =>
+  match hasDecEq a c with
+  | isTrue hac  =>
+    match hasDecEq b d with
+    | isTrue hbd  => isTrue (Eq.subst hac (Eq.subst hbd rfl))
+    | isFalse nbd => isFalse (λ h => sort.noConfusion h (λ _ hnb => absurd hnb nbd))
+  | isFalse nac => isFalse (λ h => sort.noConfusion h (λ hac _ => absurd hac nac))
+
+instance : DecidableEq sort := sort.hasDecEq
+
 protected def beq : sort → sort → Bool
 | smt_bool, smt_bool => true
 | bitvec n, bitvec m => n == m
@@ -68,7 +91,11 @@ def to_sexpr : sort -> SExpr
 | array k v => SExpr.app (atom "Array") [to_sexpr k, to_sexpr v]
 
 instance : HasToSExpr sort := ⟨sort.to_sexpr⟩
-          
+
+def toString (s:sort) := s.to_sexpr.sexpr
+
+instance : HasToString sort := ⟨sort.toString⟩
+
 end sort
 
 namespace Raw


### PR DESCRIPTION
@simonjwinwood I've got parsing implemented for everything I think we'll need for all the demos.

The only two remaining issues I'm aware of are:

#### 1) Well-typed SMT term generation

W.r.t. generating well-typed SMT terms from the parsed preconditions (i.e., [BlockExpr](https://github.com/pnwamk/reopt-vcg/blob/4abe3bae0f5ef98c9711b04a8acfea8eebb59456/lean4/app/SMTParser.lean#L72)s), I still need to fix probably the following:
  + how to properly emit a variable name with a known sort (I have a something that has the right type but is almost certainly using the wrong part of the API [here](https://github.com/pnwamk/reopt-vcg/blob/4abe3bae0f5ef98c9711b04a8acfea8eebb59456/lean4/app/SMTParser.lean#L220))
  + how to properly emit a well-typed application of a non-builtin, llvm-related (undefined, I assume) function applied to one or more argument, e.g. `(fnstart reg13)`, `(llvm foo)`, etc. Currently I just left [these BlockExpr terms](https://github.com/pnwamk/reopt-vcg/blob/4abe3bae0f5ef98c9711b04a8acfea8eebb59456/lean4/app/SMTParser.lean#L229) as "TODO"s basically.

At the moment I'm assuming we'll need to set up some initial environment with properly typed SMT function declarations (using [define_fun](https://github.com/pnwamk/reopt-vcg/blob/4abe3bae0f5ef98c9711b04a8acfea8eebb59456/lean4/deps/smtlib/src/SMTLIB/Syntax.lean#L642)?) that is a necessary parameter to the [toSMT](https://github.com/pnwamk/reopt-vcg/blob/4abe3bae0f5ef98c9711b04a8acfea8eebb59456/lean4/app/SMTParser.lean#L224) function, but I haven't dug enough to verify or fully understand that part yet.

#### 2) Build issue for tests at the moment =\

As of 4abe3ba I'm getting a linker issue issue when it tries to build the test suite:

```
/home/vagrant/reopt-vcg/lean4/../local/bin/leanc -fPIC -ggdb3 `llvm-config-8 --cxxflags` -Wno-variadic-macros -Wno-gnu-zero-variadic-macro-arguments  -fexceptions -o build/reopt-vcg-unit-test build/deps/galois_stdlib/src/Galois/Data/Array.cpp build/deps/galois_stdlib/src/Galois/Data/Bitvec.cpp build/deps/galois_stdlib/src/Galois/Data/ByteArray.cpp build/deps/galois_stdlib/src/Galois/Data/RBMap.cpp build/deps/galois_stdlib/src/Galois/Data/SExp.cpp build/deps/galois_stdlib/src/Galois/Init/Int.cpp build/deps/galois_stdlib/src/Galois/Init/Io.cpp build/deps/galois_stdlib/src/Galois/Init/Nat.cpp build/deps/galois_stdlib/src/Galois/Init/Json.cpp build/deps/galois_stdlib/src/Galois/Category/Coe1.cpp build/deps/galois_stdlib/src/Galois/Data/ParserComb.cpp build/deps/smtlib/src/SMTLIB/Syntax.cpp build/deps/lean-llvm/src/Alignment.cpp build/deps/lean-llvm/src/AST.cpp build/deps/lean-llvm/src/PP.cpp build/deps/lean-llvm/src/DataLayout.cpp build/deps/lean-llvm/src/LLVMCodes.cpp build/deps/lean-llvm/src/LLVMFFI.cpp build/deps/lean-llvm/src/LLVMLib.cpp build/deps/lean-llvm/src/LLVMOutput.cpp build/deps/lean-llvm/src/Memory.cpp build/deps/lean-llvm/src/SimMonad.cpp build/deps/lean-llvm/src/Simulate.cpp build/deps/lean-llvm/src/Parser.cpp build/deps/lean-llvm/src/TypeContext.cpp build/deps/lean-llvm/src/Value.cpp build/deps/llvm-tablegen-support/lean/DecodeX86.cpp build/deps/x86_semantics/src/X86Semantics/BufferMap.cpp build/deps/x86_semantics/src/X86Semantics/Common.cpp build/deps/x86_semantics/src/X86Semantics/BackendAPI.cpp build/deps/x86_semantics/src/X86Semantics/ConcreteBackend.cpp build/deps/x86_semantics/src/X86Semantics/SymbolicBackend.cpp build/deps/x86_semantics/src/X86Semantics/Evaluator.cpp build/deps/x86_semantics/src/X86Semantics/Instructions.cpp build/deps/x86_semantics/src/X86Semantics/MachineMemory.cpp build/simulator/Elf.cpp build/simulator/Runelf.cpp build/simulator/Translate.cpp build/app/Annotations.cpp build/app/LoadLLVM.cpp build/app/ReoptVCG.cpp build/app/SMTParser.cpp build/app/Types.cpp build/app/VCGBackend.cpp build/app/VCGBlock.cpp build/tests/JsonRoundtrip.cpp build/tests/LoadElf.cpp build/tests/SExp.cpp build/deps/galois_stdlib/src/Galois/Init/io_runtime.o build/deps/lean-llvm/src/llvm_exports.o build/deps/llvm-tablegen-support/src/Metadata.o build/deps/llvm-tablegen-support/src/lean_support.o build/deps/llvm-tablegen-support/src/X86Disassembler.o build/tests/Main.cpp `llvm-config-8 --ldflags --system-libs --libs x86` -lstdc++ -lm
/usr/bin/clang-8
/usr/bin/clang-8
/tmp/Main-8fdb28.o: In function `_init_l_Test_tests___closed__13':
/home/vagrant/reopt-vcg/lean4/build/tests/Main.cpp:2611: undefined reference to `l_ReoptVCG_parseReachableBlockAnn___rarg___closed__10'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
Makefile:106: recipe for target 'build/reopt-vcg-unit-test' failed
make: *** [build/reopt-vcg-unit-test] Error 1
```

I haven't yet taken a chance to dive into this yet =\ Will report when I figure out more.

Update: the build seems to work on TravisCI... I just blew away and rebuilt it locally and I'm getting the same error... hmm...