### PR TITLE
fix: correct isBitSet for K backend

### DIFF
--- a/deps/k-x86-semantics/src/KX86Semantics/Compat.lean
+++ b/deps/k-x86-semantics/src/KX86Semantics/Compat.lean
@@ -94,7 +94,7 @@ def setRegister {t : type} (r : lhs t) (e : expression t) : semantics Unit := (s
 def notBool_ (e : bit) : bit := eq e bit_zero
 
 def isBitSet {n : Nat} (e : bv n) (idx : Nat) : bit := 
-  expression.bit_test e (expression.bv_nat n (n - idx))
+  expression.bit_test e (expression.bv_nat n (n - idx - 1))
 
 def overflowFlag {n : Nat} (e1 : bv n) (e2 : bv n) (r : bv n) : bit :=
     sadd_overflows e1 e2


### PR DESCRIPTION
The MSB in the K backend is bit 0, whereas in our semantics
(where the larger indices are more significant) the MSB for a 
bit vector of size `n` is 0-based index `n-0-1` (not `n-0`),
etc.