### PR TITLE
feat: exit codes report failure via bit flags

### DIFF
--- a/deps/reopt_vcg/Makefile.include
+++ b/deps/reopt_vcg/Makefile.include
@@ -3,7 +3,7 @@
 LOCAL_LEAN := src/ReoptVCG/Annotations.lean src/ReoptVCG/LoadLLVM.lean\
               src/ReoptVCG/ReoptVCG.lean src/ReoptVCG/SmtParser.lean\
               src/ReoptVCG/Types.lean src/ReoptVCG/VCGBlock.lean\
-              src/ReoptVCG/Elf.lean src/ReoptVCG/MCStdLib.lean\
+              src/ReoptVCG/Elf.lean src/ReoptVCG/ExitFlag.lean src/ReoptVCG/MCStdLib.lean\
               src/ReoptVCG/Smt.lean \
               src/ReoptVCG/Translate.lean src/ReoptVCG/KTranslate.lean\
               src/ReoptVCG/VCGBackend.lean src/ReoptVCG/WordSize.lean\

--- a/deps/reopt_vcg/src/ReoptVCG/ExitFlag.lean
+++ b/deps/reopt_vcg/src/ReoptVCG/ExitFlag.lean
@@ -1,0 +1,11 @@
+
+
+/-- Flag indicating some non-zero number of verification conditions failed to be
+  verified when passed to an SMT solver. -/
+def ExitFlag.verificationFailure : UInt32 := 0b001
+
+/-- Flag indicating an error occured while querying the SMT solver. -/
+def ExitFlag.verificationError : UInt32 := 0b010
+
+/-- Flag indicating an error occured while generating verification conditions. -/
+def ExitFlag.generationError : UInt32 := 0b100


### PR DESCRIPTION
A non-zero exit status now uses bit flags to indicate what went wrong:

```
/-- Flag indicating some non-zero number of verification conditions failed to be
  verified when passed to an SMT solver. -/
def ExitFlag.verificationFailure : UInt32 := 0b001

/-- Flag indicating an error occured while querying the SMT solver. -/
def ExitFlag.verificationError : UInt32 := 0b010

/-- Flag indicating an error occured while generating verification conditions. -/
def ExitFlag.generationError : UInt32 := 0b100
```